### PR TITLE
fix refreshing vnstati in the beginning

### DIFF
--- a/hostapd-statistics/etc/hostapd-statistics/javascript1.js
+++ b/hostapd-statistics/etc/hostapd-statistics/javascript1.js
@@ -37,8 +37,9 @@ xmlhttp2.onreadystatechange=function()
     document.getElementById("VnstatiHolder").innerHTML=xmlhttp2.responseText;
    }
   }
-xmlhttp.open("GET","refreshvnstati",true);
-xmlhttp.send();
+xmlhttp2.open("GET","refreshvnstati",true);
+xmlhttp2.send();
 setTimeout(refreshVnstati, 120000);
 }
+refreshVnstati();
 </script>


### PR DESCRIPTION
Vnstats would dissapear until the first update at 2 minutes. This change
should fix that.
